### PR TITLE
PRDENG-33134 | Add additional Quickfix Message defintions

### DIFF
--- a/lib/quickfix50sp2.rb
+++ b/lib/quickfix50sp2.rb
@@ -412441,4 +412441,47 @@ class PayManagementRequestAck < Message
 		getHeader().setField( Quickfix::MsgType.new("DZ") )
 	end
 end
+
+class MarketSettlementReport < Message
+	def initialize
+		super
+		getHeader().setField( Quickfix::MsgType.new("UMS") )
+	end
+
+	class NoMarketSettlementPartyIDs < Quickfix::Group
+		def initialize
+			order = Quickfix::IntArray.new(7)
+			order[0] = 20109
+			order[1] = 20110
+			order[2] = 704
+			order[3] = 705
+			order[4] = 1703
+			order[5] = 136
+			order[6] = 0
+			super(20108, 20109, order)
+		end
+
+		class NoCollateralAmounts < Quickfix::Group
+			def initialize
+				order = Quickfix::IntArray.new(3)
+				order[0] = 1704
+				order[1] = 1705
+				order[2] = 0
+				super(1703, 1704, order)
+			end
+		end
+
+		class NoMiscFees < Quickfix::Group
+			def initialize
+				order = Quickfix::IntArray.new(5)
+				order[0] = 137
+				order[1] = 138
+				order[2] = 139
+				order[3] = 891
+				order[4] = 0
+				super(136, 137, order)
+			end
+		end
+	end
+end
 end

--- a/lib/quickfix_fields.rb
+++ b/lib/quickfix_fields.rb
@@ -79390,4 +79390,121 @@ module Quickfix
 		end
 	end
 
+	class SettlementPrice < Quickfix::DoubleField
+		def SettlementPrice.field
+			return 730
+		end
+		def initialize(data = nil)
+			if( data == nil )
+				super(730)
+			else
+				super(730, data)
+			end
+		end
+	end
+
+	class NoCollateralAmountChanges < Quickfix::IntField
+		def NoCollateralAmountChanges.field
+			return 1703
+		end
+		def initialize(data = nil)
+			if( data == nil )
+				super(1703)
+			else
+				super(1703, data)
+			end
+		end
+	end
+
+	class CollateralAmountChange < Quickfix::DoubleField
+		def CollateralAmountChange.field
+			return 1704
+		end
+		def initialize(data = nil)
+			if( data == nil )
+				super(1704)
+			else
+				super(1704, data)
+			end
+		end
+	end
+
+	class MarketSettlementReportID < Quickfix::StringField
+		def MarketSettlementReportID.field
+			return 20105
+		end
+		def initialize(data = nil)
+			if( data == nil )
+				super(20105)
+			else
+				super(20105, data)
+			end
+		end
+	end
+
+	class TotNumMarketSettlementReports < Quickfix::IntField
+		def TotNumMarketSettlementReports.field
+			return 20106
+		end
+		def initialize(data = nil)
+			if( data == nil )
+				super(20106)
+			else
+				super(20106, data)
+			end
+		end
+	end
+
+	class MarketResult < Quickfix::StringField
+		def MarketResult.field
+			return 20107
+		end
+		def initialize(data = nil)
+			if( data == nil )
+				super(20107)
+			else
+				super(20107, data)
+			end
+		end
+	end
+
+	class NoMarketSettlementPartyIDs < Quickfix::IntField
+		def NoMarketSettlementPartyIDs.field
+			return 20108
+		end
+		def initialize(data = nil)
+			if( data == nil )
+				super(20108)
+			else
+				super(20108, data)
+			end
+		end
+	end
+
+	class MarketSettlementPartyID < Quickfix::StringField
+		def MarketSettlementPartyID.field
+			return 20109
+		end
+		def initialize(data = nil)
+			if( data == nil )
+				super(20109)
+			else
+				super(20109, data)
+			end
+		end
+	end
+
+	class MarketSettlementPartyRole < Quickfix::IntField
+		def MarketSettlementPartyRole.field
+			return 20110
+		end
+		def initialize(data = nil)
+			if( data == nil )
+				super(20110)
+			else
+				super(20110, data)
+			end
+		end
+	end
+
 end

--- a/quickfix_ruby_ud.gemspec
+++ b/quickfix_ruby_ud.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'quickfix_ruby_ud'
-  s.version     = '2.0.8'
-  s.date        = '2025-04-23'
+  s.version     = '2.0.9'
+  s.date        = '2026-02-07'
   s.summary     = 'QuickFIX'
   s.description = 'FIX (Financial Information eXchange) protocol implementation'
   s.authors     = ['Oren Miller', 'Tom Kerr']


### PR DESCRIPTION
Current set up in [this](https://github.com/Underdog-Inc/api/pull/19502) will define these new defintions directly in the api code, but to follow the pattern we've established opening a PR to get them added to the quickfix_ruby_ud gem

### Next Steps After Merging

1. **Build and publish the gem** — Run `./package.sh` from the repo root. This builds the gem for `aarch64-linux` and `x86_64-linux` platforms and pushes version `2.0.9` to RubyGems (requires write access).

2. **Update the FIX data dictionary XML** — In the application that consumes this gem, add the `MarketSettlementReport` message definition (msgtype `UMS`) and the custom field definitions (tags 20105–20110) to your FIX50SP2.xml data dictionary so the FIX engine can parse `UMS` messages. The Kalshi FIX dictionary XML is also available for reference at: https://kalshi-public-docs.s3.us-east-1.amazonaws.com/fix/kalshi-fix-dictionary.xml 
✅ This is already being done in [this](https://github.com/Underdog-Inc/api/pull/19502)

3. **Update the consuming application** — Bump `quickfix_ruby_ud` to `~> 2.0.9` in the Gemfile and run `bundle update quickfix_ruby_ud`. The new field classes (`Quickfix::MarketSettlementReportID`, `Quickfix::MarketResult`, etc.) and the message class (`Quickfix50Sp2::MarketSettlementReport`) will then be available.

4. **Field name mapping** — Note that some Kalshi doc names differ from the standard FIX field names used in this gem.  Alias classes were added so they should map correctly regardless of which alias we call from the api repo:
   - "SettlementPrice" (730) → `Quickfix::SettlPrice`
   - "CollateralAmountChange" (1704) → `Quickfix::CurrentCollateralAmount`
   - "CollateralAmountType" (1705) → `Quickfix::CollateralCurrency`