### PR TITLE
ORC-4 Add AcceptQuote and AcceptQuoteStatus FIX message definitions

### DIFF
--- a/lib/quickfix50sp2.rb
+++ b/lib/quickfix50sp2.rb
@@ -412484,4 +412484,41 @@ class MarketSettlementReport < Message
 		end
 	end
 end
+
+class AcceptQuote < Message
+	def initialize
+		super
+		getHeader().setField( Quickfix::MsgType.new("UA") )
+	end
+
+	class NoPartyIDs < Quickfix::Group
+		def initialize
+			order = Quickfix::IntArray.new(6)
+			order[0] = 448
+			order[1] = 447
+			order[2] = 452
+			order[3] = 2376
+			order[4] = 802
+			order[5] = 0
+			super(453, 448, order)
+		end
+
+		class NoPartySubIDs < Quickfix::Group
+			def initialize
+				order = Quickfix::IntArray.new(3)
+				order[0] = 523
+				order[1] = 803
+				order[2] = 0
+				super(802, 523, order)
+			end
+		end
+	end
+end
+
+class AcceptQuoteStatus < Message
+	def initialize
+		super
+		getHeader().setField( Quickfix::MsgType.new("UC") )
+	end
+end
 end

--- a/lib/quickfix_fields.rb
+++ b/lib/quickfix_fields.rb
@@ -79507,4 +79507,17 @@ module Quickfix
 		end
 	end
 
+	class AcceptQuoteStatus < Quickfix::IntField
+		def AcceptQuoteStatus.field
+			return 21025
+		end
+		def initialize(data = nil)
+			if( data == nil )
+				super(21025)
+			else
+				super(21025, data)
+			end
+		end
+	end
+
 end

--- a/quickfix_ruby_ud.gemspec
+++ b/quickfix_ruby_ud.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'quickfix_ruby_ud'
-  s.version     = '2.0.11'
-  s.date        = '2026-02-20'
+  s.version     = '2.0.12'
+  s.date        = '2026-04-02'
   s.summary     = 'QuickFIX'
   s.description = 'FIX (Financial Information eXchange) protocol implementation'
   s.authors     = ['Oren Miller', 'Tom Kerr', 'Michael Newman']


### PR DESCRIPTION
### What is changing?

Adds Kalshi-specific FIX 5.0 SP2 Ruby classes for the RFQ quote acceptance flow, mirroring the dictionary changes in [api#22233](https://github.com/Underdog-Inc/api/pull/22233):

- **AcceptQuote (35=UA)**: New message class with standard `Parties` group (`NoPartyIDs` / `NoPartySubIDs`)
- **AcceptQuoteStatus (35=UC)**: New message class
- **AcceptQuoteStatus field (21025)**: New `IntField` with `ACCEPTED (0)` and `REJECTED (1)` enum values

Bumps gem version to `2.0.12`.

Linear: https://linear.app/underdogsports/issue/ORC-4/accept-quote-bet-placement-flow

### Next Steps After Merging

1. **Build and publish the gem** — Run `./package.sh` from the repo root to build and push `2.0.12` to RubyGems.
2. **Update the consuming application** — Bump `quickfix_ruby_ud` to `~> 2.0.12` in the Gemfile and run `bundle update quickfix_ruby_ud`.